### PR TITLE
user, issue api 구현, error handler 추가, seeder 더미데이터 추가

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -15,3 +15,19 @@ app.use(express.urlencoded({ extended: false }));
 app.use('/api', indexController);
 
 app.listen(8080);
+
+// catch 404 and forward to error handler
+app.use(function (req, res, next) {
+  next(createError(404));
+});
+
+// error handler
+app.use(function (err, req, res, next) {
+  // set locals, only providing error in development
+  res.locals.message = err.message;
+  res.locals.error = req.app.get('env') === 'production' ? err : {};
+
+  // render the error page
+  res.status(err.status || 500);
+  res.send('error');
+});

--- a/server/controllers/user.js
+++ b/server/controllers/user.js
@@ -10,11 +10,7 @@ router.get(
   '/',
   wrapAsync(async (req, res, next) => {
     const users = await User.findAll();
-    return res.status(200).json({
-      status: 200,
-      data: users,
-      message: 'Succesfully Users Retrieved',
-    });
+    return res.status(200).json({ users });
   }),
 );
 
@@ -23,7 +19,7 @@ router.post(
   wrapAsync(async (req, res, next) => {
     const { email, imageUrl, name } = req.body;
 
-    const use = await User.create({
+    const user = await User.create({
       email,
       imageUrl,
       name,

--- a/server/database/seeders/20201102080307-seed.js
+++ b/server/database/seeders/20201102080307-seed.js
@@ -127,6 +127,24 @@ const issueAssignee = [
     createdAt: new Date(),
     updatedAt: new Date(),
   },
+  {
+    issueId: 1,
+    userId: 2,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+  {
+    issueId: 2,
+    userId: 1,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+  {
+    issueId: 2,
+    userId: 3,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
 ];
 
 const issueLabel = [
@@ -139,6 +157,18 @@ const issueLabel = [
   {
     issueId: 1,
     labelId: 2,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+  {
+    issueId: 2,
+    labelId: 1,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+  {
+    issueId: 2,
+    labelId: 3,
     createdAt: new Date(),
     updatedAt: new Date(),
   },


### PR DESCRIPTION
## 구현내용

### [feat]
* user, issue api 구현
- user는 get만 정상 작동 확인. 리펙토링 필요
- issue는 isOpen, createrId, milestoneId에 대해 필터 가능한 get 라우터 구현
- 이슈 생성, 삭제, 수정 구현
- issueAssignee, issueLabels 추가, 삭제 구현
* app.js 파일에 error handler 추가
* seeder 더미데이터 추가