### PR TITLE
데이터 받아서 이슈 상세 화면 표시 

### DIFF
--- a/client/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
+++ b/client/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
@@ -54,13 +54,13 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="w0V-ov-XLz" userLabel="labelLabel" customClass="BadgeLabel" customModule="IssueTracker" customModuleProvider="target">
-                                                    <rect key="frame" x="336.66666666666669" y="11" width="41.333333333333314" height="18"/>
+                                                    <rect key="frame" x="322.66666666666669" y="11" width="55.333333333333314" height="16"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lxP-SJ-cxA" customClass="BadgeLabel" customModule="IssueTracker" customModuleProvider="target">
-                                                    <rect key="frame" x="336.66666666666669" y="34" width="41.333333333333314" height="20.333333333333329"/>
+                                                    <rect key="frame" x="322.66666666666669" y="32" width="55.333333333333314" height="24.333333333333329"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -217,13 +217,13 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Wg-Ir-mVQ" userLabel="labelLabel" customClass="BadgeLabel" customModule="IssueTracker" customModuleProvider="target">
-                                                    <rect key="frame" x="372.66666666666669" y="11" width="41.333333333333314" height="18"/>
+                                                    <rect key="frame" x="358.66666666666669" y="11" width="55.333333333333314" height="16"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OXl-hx-xEf" customClass="BadgeLabel" customModule="IssueTracker" customModuleProvider="target">
-                                                    <rect key="frame" x="372.66666666666669" y="34" width="41.333333333333314" height="20.333333333333329"/>
+                                                    <rect key="frame" x="358.66666666666669" y="32" width="55.333333333333314" height="24.333333333333329"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -650,19 +650,19 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="745" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jqK-KH-Ipy" customClass="BadgeLabel" customModule="IssueTracker" customModuleProvider="target">
-                                                    <rect key="frame" x="18.000000000000004" y="9.9999999999999982" width="41.333333333333343" height="20.333333333333329"/>
+                                                    <rect key="frame" x="18.000000000000004" y="9.9999999999999982" width="55.333333333333343" height="24.333333333333329"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2020년 11월 4일까지" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VTO-eU-3bh">
-                                                    <rect key="frame" x="77.333333333333314" y="14" width="108" height="15"/>
+                                                    <rect key="frame" x="91.333333333333314" y="14" width="108" height="15"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                     <color key="textColor" systemColor="systemGrayColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="745" text="이번 배포를 위한 마일스톤" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sHt-9S-YR5">
-                                                    <rect key="frame" x="18" y="43.333333333333336" width="175" height="20.333333333333336"/>
+                                                    <rect key="frame" x="18" y="47.333333333333336" width="175" height="20.333333333333336"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="20.333333333333336" id="3nI-3F-Ffr"/>
                                                     </constraints>
@@ -807,19 +807,19 @@
     </scenes>
     <designables>
         <designable name="2Wg-Ir-mVQ">
-            <size key="intrinsicContentSize" width="41.333333333333336" height="20.333333333333332"/>
+            <size key="intrinsicContentSize" width="55.333333333333336" height="24.333333333333332"/>
         </designable>
         <designable name="OXl-hx-xEf">
-            <size key="intrinsicContentSize" width="41.333333333333336" height="20.333333333333332"/>
+            <size key="intrinsicContentSize" width="55.333333333333336" height="24.333333333333332"/>
         </designable>
         <designable name="jqK-KH-Ipy">
-            <size key="intrinsicContentSize" width="41.333333333333336" height="20.333333333333332"/>
+            <size key="intrinsicContentSize" width="55.333333333333336" height="24.333333333333332"/>
         </designable>
         <designable name="lxP-SJ-cxA">
-            <size key="intrinsicContentSize" width="41.333333333333336" height="20.333333333333332"/>
+            <size key="intrinsicContentSize" width="55.333333333333336" height="24.333333333333332"/>
         </designable>
         <designable name="w0V-ov-XLz">
-            <size key="intrinsicContentSize" width="41.333333333333336" height="20.333333333333332"/>
+            <size key="intrinsicContentSize" width="55.333333333333336" height="24.333333333333332"/>
         </designable>
     </designables>
     <resources>

--- a/client/iOS/IssueTracker/IssueTracker/BottomViewController.swift
+++ b/client/iOS/IssueTracker/IssueTracker/BottomViewController.swift
@@ -9,6 +9,8 @@ import UIKit
 import SwiftUI
 
 class BottomViewController: UIViewController {
+    
+    var issue: Issue?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -16,7 +18,8 @@ class BottomViewController: UIViewController {
     }
     
     @IBSegueAction func addSwiftUIView(_ coder: NSCoder) -> UIViewController? {
-        return UIHostingController(coder: coder, rootView: SwiftUIView())
+        guard let issue = issue else { return nil }
+        return UIHostingController(coder: coder, rootView: SwiftUIView(issue: issue))
     }
 
 }

--- a/client/iOS/IssueTracker/IssueTracker/Controller/IssueListViewController.swift
+++ b/client/iOS/IssueTracker/IssueTracker/Controller/IssueListViewController.swift
@@ -160,13 +160,13 @@ extension IssueListViewController: UICollectionViewDelegate {
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let issue = self.dataSource.itemIdentifier(for: indexPath) else { return }
-//        presentAsNavigator(issue: issue)
-        presentCustomBottomSheet()
+        presentAsNavigator(issue: issue)
+//        presentCustomBottomSheet()
     }
     
     private func presentAsNavigator(issue: Issue) {
         guard let detailViewController = self.storyboard?.instantiateViewController(withIdentifier: "BottomViewController") as? BottomViewController else { return }
-        // detailViewController.issue = issue
+        detailViewController.issue = issue
         navigationController?.pushViewController(detailViewController, animated: true)
     }
     

--- a/client/iOS/IssueTracker/IssueTracker/Controller/NewIssueViewController.swift
+++ b/client/iOS/IssueTracker/IssueTracker/Controller/NewIssueViewController.swift
@@ -56,7 +56,7 @@ class NewIssueViewController: UIViewController {
     private func createIssue(_ title: String) -> Issue {
         let content = contentTextView.text
         
-        let firstComment = Comment(id: nil, isFirst: true, createdAt: nil, updatedAt: nil, content: content)
+        let firstComment = Comment(id: nil, isFirst: true, creater: nil, createdAt: nil, updatedAt: nil, content: content)
         return Issue(id: nil, title: title, firstComment: firstComment, isOpen: true, createdAt: nil, updatedAt: nil, creater: nil, milestone: nil, assignees: nil, comments: nil, labels: nil)
     }
     

--- a/client/iOS/IssueTracker/IssueTracker/SwiftUI/BottomSheetView.swift
+++ b/client/iOS/IssueTracker/IssueTracker/SwiftUI/BottomSheetView.swift
@@ -12,29 +12,30 @@ struct BottomSheetView: View {
     @State var showingNewComment = false
     @Binding var offset: CGFloat
     var value: CGFloat
+    var issue: Issue
     
-    let user1 = User(id: 1, email: "yeonduing@gmail.com", imageUrl: nil, name: "yeonduing")
-    let user2 = User(id: 2, email: "yeonduing@gmail.com", imageUrl: nil, name: "yeonduing")
-    let user3 = User(id: 3, email: "yeonduing@gmail.com", imageUrl: nil, name: "yeonduing")
-    let user4 = User(id: 4, email: "yeonduing@gmail.com", imageUrl: nil, name: "yeonduing")
-    let user5 = User(id: 5, email: "yeonduing@gmail.com", imageUrl: nil, name: "yeonduing")
-    let user6 = User(id: 6, email: "yeonduing@gmail.com", imageUrl: nil, name: "yeonduing")
-    let milestone = Milestone(id: nil, title: "Week3", description: nil, isOpen: true, dueDate: nil)
-    let label1 = Label(id: 1, title: "iOS", description: nil, color: "#F01932")
-    let label2 = Label(id: 2, title: "iOS", description: nil, color: "#F01932")
-    let label3 = Label(id: 3, title: "iOS", description: nil, color: "#F01932")
-    let label4 = Label(id: 4, title: "iOㄴㅁㅇ라ㅓ망러S", description: nil, color: "#F01932")
-    let label5 = Label(id: 5, title: "iOS", description: nil, color: "#F01932")
-    let label6 = Label(id: 6, title: "iOS", description: nil, color: "#F01932")
-    let label7 = Label(id: 7, title: "아러망럼ㅇ러망럼ㅇ라ㅓ", description: nil, color: "#F01932")
-    let label8 = Label(id: 8, title: "iO아럼ㅇ럼아러댜ㅓㄹㅁS", description: nil, color: "#F01932")
-    let label9 = Label(id: 9, title: "iO아럼ㅇ라ㅓㅁ아럼ㅇS", description: nil, color: "#F01932")
+//    let user1 = User(id: 1, email: "yeonduing@gmail.com", imageUrl: nil, name: "yeonduing")
+//    let user2 = User(id: 2, email: "yeonduing@gmail.com", imageUrl: nil, name: "yeonduing")
+//    let user3 = User(id: 3, email: "yeonduing@gmail.com", imageUrl: nil, name: "yeonduing")
+//    let user4 = User(id: 4, email: "yeonduing@gmail.com", imageUrl: nil, name: "yeonduing")
+//    let user5 = User(id: 5, email: "yeonduing@gmail.com", imageUrl: nil, name: "yeonduing")
+//    let user6 = User(id: 6, email: "yeonduing@gmail.com", imageUrl: nil, name: "yeonduing")
+//    let milestone = Milestone(id: nil, title: "Week3", description: nil, isOpen: true, dueDate: nil)
+//    let label1 = Label(id: 1, title: "iOS", description: nil, color: "#F01932")
+//    let label2 = Label(id: 2, title: "iOS", description: nil, color: "#F01932")
+//    let label3 = Label(id: 3, title: "iOS", description: nil, color: "#F01932")
+//    let label4 = Label(id: 4, title: "iOㄴㅁㅇ라ㅓ망러S", description: nil, color: "#F01932")
+//    let label5 = Label(id: 5, title: "iOS", description: nil, color: "#F01932")
+//    let label6 = Label(id: 6, title: "iOS", description: nil, color: "#F01932")
+//    let label7 = Label(id: 7, title: "아러망럼ㅇ러망럼ㅇ라ㅓ", description: nil, color: "#F01932")
+//    let label8 = Label(id: 8, title: "iO아럼ㅇ럼아러댜ㅓㄹㅁS", description: nil, color: "#F01932")
+//    let label9 = Label(id: 9, title: "iO아럼ㅇ라ㅓㅁ아럼ㅇS", description: nil, color: "#F01932")
     
     var gridItemLayout = [GridItem(.adaptive(minimum: 70))]
     var gridItemLayoutOfLable = [GridItem(.adaptive(minimum: 70))]
     
     var body: some View {
-        let issue = Issue(id: nil, title: "bottomSheet 구성", firstComment: Comment(id: nil, isFirst: true, creater: user1, createdAt: nil, updatedAt: nil, content: "swiftUI 사용"), isOpen: true, createdAt: nil, updatedAt: nil, creater: user1, milestone: milestone, assignees: [user1, user2, user3, user4, user5, user6], comments: nil, labels: [label1, label2, label3, label4, label5, label6, label7, label8, label9])
+//        let issue = Issue(id: nil, title: "bottomSheet 구성", firstComment: Comment(id: nil, isFirst: true, creater: user1, createdAt: nil, updatedAt: nil, content: "swiftUI 사용"), isOpen: true, createdAt: nil, updatedAt: nil, creater: user1, milestone: milestone, assignees: [user1, user2, user3, user4, user5, user6], comments: nil, labels: [label1, label2, label3, label4, label5, label6, label7, label8, label9])
         
         VStack {
             Capsule()
@@ -110,9 +111,25 @@ struct BottomSheetView: View {
                     Text("마일스톤")
                         .font(.title2)
                         .fontWeight(.bold)
-                    MilestoneView(Milestone(id: nil, title: "Week3", description: nil, isOpen: true, dueDate: nil))
+                    if let milestone = issue.milestone {
+                        MilestoneView(milestone)
+                    }
                     Divider()
                         .padding(.top, 10)
+                    
+                    Button(action: {
+                        self.showingNewComment.toggle()
+                    }) {
+                        HStack {
+                            Spacer()
+                            Text("Close Issue")
+                                .font(.headline)
+                                .foregroundColor(Color(UIColor.systemRed))
+                            Spacer()
+                        }
+                    }.sheet(isPresented: $showingNewComment) {
+                        NewCommentView()
+                    }.buttonStyle(RoundedRectangleButtonStyle())
                 })
                 .padding()
                 .padding(.top)

--- a/client/iOS/IssueTracker/IssueTracker/SwiftUI/BottomSheetView.swift
+++ b/client/iOS/IssueTracker/IssueTracker/SwiftUI/BottomSheetView.swift
@@ -14,28 +14,10 @@ struct BottomSheetView: View {
     var value: CGFloat
     var issue: Issue
     
-//    let user1 = User(id: 1, email: "yeonduing@gmail.com", imageUrl: nil, name: "yeonduing")
-//    let user2 = User(id: 2, email: "yeonduing@gmail.com", imageUrl: nil, name: "yeonduing")
-//    let user3 = User(id: 3, email: "yeonduing@gmail.com", imageUrl: nil, name: "yeonduing")
-//    let user4 = User(id: 4, email: "yeonduing@gmail.com", imageUrl: nil, name: "yeonduing")
-//    let user5 = User(id: 5, email: "yeonduing@gmail.com", imageUrl: nil, name: "yeonduing")
-//    let user6 = User(id: 6, email: "yeonduing@gmail.com", imageUrl: nil, name: "yeonduing")
-//    let milestone = Milestone(id: nil, title: "Week3", description: nil, isOpen: true, dueDate: nil)
-//    let label1 = Label(id: 1, title: "iOS", description: nil, color: "#F01932")
-//    let label2 = Label(id: 2, title: "iOS", description: nil, color: "#F01932")
-//    let label3 = Label(id: 3, title: "iOS", description: nil, color: "#F01932")
-//    let label4 = Label(id: 4, title: "iOㄴㅁㅇ라ㅓ망러S", description: nil, color: "#F01932")
-//    let label5 = Label(id: 5, title: "iOS", description: nil, color: "#F01932")
-//    let label6 = Label(id: 6, title: "iOS", description: nil, color: "#F01932")
-//    let label7 = Label(id: 7, title: "아러망럼ㅇ러망럼ㅇ라ㅓ", description: nil, color: "#F01932")
-//    let label8 = Label(id: 8, title: "iO아럼ㅇ럼아러댜ㅓㄹㅁS", description: nil, color: "#F01932")
-//    let label9 = Label(id: 9, title: "iO아럼ㅇ라ㅓㅁ아럼ㅇS", description: nil, color: "#F01932")
-    
     var gridItemLayout = [GridItem(.adaptive(minimum: 70))]
     var gridItemLayoutOfLable = [GridItem(.adaptive(minimum: 70))]
     
     var body: some View {
-//        let issue = Issue(id: nil, title: "bottomSheet 구성", firstComment: Comment(id: nil, isFirst: true, creater: user1, createdAt: nil, updatedAt: nil, content: "swiftUI 사용"), isOpen: true, createdAt: nil, updatedAt: nil, creater: user1, milestone: milestone, assignees: [user1, user2, user3, user4, user5, user6], comments: nil, labels: [label1, label2, label3, label4, label5, label6, label7, label8, label9])
         
         VStack {
             Capsule()

--- a/client/iOS/IssueTracker/IssueTracker/SwiftUI/BottomSheetView.swift
+++ b/client/iOS/IssueTracker/IssueTracker/SwiftUI/BottomSheetView.swift
@@ -8,7 +8,11 @@
 import SwiftUI
 
 struct BottomSheetView: View {
+    
     @State var showingNewComment = false
+    @Binding var offset: CGFloat
+    var value: CGFloat
+    
     let user1 = User(id: 1, email: "yeonduing@gmail.com", imageUrl: nil, name: "yeonduing")
     let user2 = User(id: 2, email: "yeonduing@gmail.com", imageUrl: nil, name: "yeonduing")
     let user3 = User(id: 3, email: "yeonduing@gmail.com", imageUrl: nil, name: "yeonduing")
@@ -26,11 +30,11 @@ struct BottomSheetView: View {
     let label8 = Label(id: 8, title: "iO아럼ㅇ럼아러댜ㅓㄹㅁS", description: nil, color: "#F01932")
     let label9 = Label(id: 9, title: "iO아럼ㅇ라ㅓㅁ아럼ㅇS", description: nil, color: "#F01932")
     
-    private var gridItemLayout = [GridItem(.adaptive(minimum: 70))]
-    private var gridItemLayoutOfLable = [GridItem(.adaptive(minimum: 70))]
+    var gridItemLayout = [GridItem(.adaptive(minimum: 70))]
+    var gridItemLayoutOfLable = [GridItem(.adaptive(minimum: 70))]
     
     var body: some View {
-        let issue = Issue(id: nil, title: "bottomSheet 구성", firstComment: Comment(id: nil, isFirst: true, createdAt: nil, updatedAt: nil, content: "swiftUI 사용"), isOpen: true, createdAt: nil, updatedAt: nil, creater: user1, milestone: milestone, assignees: [user1, user2, user3, user4, user5, user6], comments: nil, labels: [label1, label2, label3, label4, label5, label6, label7, label8, label9])
+        let issue = Issue(id: nil, title: "bottomSheet 구성", firstComment: Comment(id: nil, isFirst: true, creater: user1, createdAt: nil, updatedAt: nil, content: "swiftUI 사용"), isOpen: true, createdAt: nil, updatedAt: nil, creater: user1, milestone: milestone, assignees: [user1, user2, user3, user4, user5, user6], comments: nil, labels: [label1, label2, label3, label4, label5, label6, label7, label8, label9])
         
         VStack {
             Capsule()
@@ -119,11 +123,11 @@ struct BottomSheetView: View {
     }
 }
 
-struct BottomSheetView_Previews: PreviewProvider {
-    static var previews: some View {
-        BottomSheetView()
-    }
-}
+//struct BottomSheetView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        BottomSheetView()
+//    }
+//}
 
 struct RoundedRectangleButtonStyle: ButtonStyle {
     

--- a/client/iOS/IssueTracker/IssueTracker/SwiftUI/BottomSheetViewController.swift
+++ b/client/iOS/IssueTracker/IssueTracker/SwiftUI/BottomSheetViewController.swift
@@ -16,7 +16,7 @@ class BottomSheetViewController: UIViewController {
         // Do any additional setup after loading the view.
     }
 
-    @IBSegueAction func addBottomSheetView(_ coder: NSCoder) -> UIViewController? {
-        return UIHostingController(coder: coder, rootView: BottomSheetView())
-    }
+//    @IBSegueAction func addBottomSheetView(_ coder: NSCoder) -> UIViewController? {
+//        return UIHostingController(coder: coder, rootView: BottomSheetView())
+//    }
 }

--- a/client/iOS/IssueTracker/IssueTracker/SwiftUIView.swift
+++ b/client/iOS/IssueTracker/IssueTracker/SwiftUIView.swift
@@ -9,24 +9,38 @@ import SwiftUI
 
 struct SwiftUIView: View {
     
-    let issue: Issue = Issue(id: 1, title: "이슈 생성 기능", isOpen: true, createdAt: "", updatedAt: "", creater: User(id: nil, email: "zhdtns2005@naver.com", imageUrl: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAAW0lEQVQ4T2NkYGBg+P///38QDQLir11gTDD9UnQPCh+dg66ecdRAjPAiFKYEw5BQoKNH0jAwEN0L6EFAspdHDcSbj7HldYJ5mZCJ6JE0BA0k5EVCyQrDy8PfQAAC85QlbKFkwQAAAABJRU5ErkJggg==", name: "성주"), milestone: nil, assignees: nil, comments: [], labels: nil)
-    let comments: [Comment] =  [
-        Comment(id: 0, isFirst: true, creater: User(id: nil, email: "zhdtns2005@naver.com", imageUrl: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAAW0lEQVQ4T2NkYGBg+P///38QDQLir11gTDD9UnQPCh+dg66ecdRAjPAiFKYEw5BQoKNH0jAwEN0L6EFAspdHDcSbj7HldYJ5mZCJ6JE0BA0k5EVCyQrDy8PfQAAC85QlbKFkwQAAAABJRU5ErkJggg==", name: "성주"), createdAt: nil, updatedAt: "2020-11-01T11:11:11.000Z", content: "안녕하세요! 훌륭 하군요 ㅎㅎ"),Comment(id: 1, isFirst: true, creater: User(id: nil, email: "zhdtns2005@naver.com", imageUrl: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAAW0lEQVQ4T2NkYGBg+P///38QDQLir11gTDD9UnQPCh+dg66ecdRAjPAiFKYEw5BQoKNH0jAwEN0L6EFAspdHDcSbj7HldYJ5mZCJ6JE0BA0k5EVCyQrDy8PfQAAC85QlbKFkwQAAAABJRU5ErkJggg==", name: "연수"), createdAt: nil, updatedAt: "2020-11-11T11:11:11.000Z", content: "안녕하세요! 호호dfafdajkdljfk아ㅓ라더랴ㅏㅁㄷ러ㅏ어라ㅣㅁ어라ㅣ머아ㅣ럼아러ㅏ밍러ㅏㅣ멍랴ㅏㅣㅁㄴ어림어라ㅣㅁ얼;ㅁ너라ㅣ먼ㅇ라ㅣㅇ너홓")]
+    var issue: Issue
+    let comments: [Comment]
     
+    init(issue: Issue) {
+        self.issue = issue
+        if let comments = issue.comments {
+            self.comments = comments
+        } else {
+            self.comments = []
+        }
+    }
+    
+
     @State var offset: CGFloat = 0
     @State var touchedCount = 0
     
     var body: some View {
         ZStack(alignment: Alignment(horizontal: .center, vertical: .center), content: {
-            //            VStack {
             List {
                 VStack (alignment: .leading) {
                     HStack{
                         Image(systemName: "person.fill")
                             .frame(width:25, height:25)
                             .clipped()
-                        Text((issue.creater?.name)!)
-                            .padding(.leading, 3)
+                        if let text = issue.creater?.name {
+                            Text(text)
+                                .padding(.leading, 3)
+                        } else {
+                            Text("")
+                                .padding(.leading, 3)
+                        }
+                        
                         Spacer()
                         Text("#\(issue.id!)")
                             .foregroundColor(Color(UIColor.systemGray))
@@ -38,6 +52,7 @@ struct SwiftUIView: View {
                 .padding(.top, 1)
                 .padding(.bottom, 1)
                 
+                
                 ForEach(comments, id: \.id) { comment in
                     // comment row
                     VStack(alignment: .leading) {
@@ -45,7 +60,13 @@ struct SwiftUIView: View {
                             Image(systemName: "person.fill").frame(width:40, height:40)
                                 .clipped()
                             VStack {
-                                Text((comment.creater?.name)!)
+                                if let text = comment.creater?.name {
+                                    Text(text)
+                                        .padding(.leading, 3)
+                                } else {
+                                    Text("")
+                                        .padding(.leading, 3)
+                                }
                                 Text(((comment.updatedAt?.timeAgoDisplay())!)).foregroundColor(Color(UIColor.systemGray))
                             }
                             Spacer()
@@ -56,24 +77,25 @@ struct SwiftUIView: View {
                                     .foregroundColor(Color(UIColor.systemGray))
                             }
                         }
-                        Text(comment.content!)
-                            .padding(.vertical, 7)
+                        if let content = comment.content {
+                            Text(content)
+                                .padding(.vertical, 7)
+                        } else {
+                            Text("")
+                                .padding(.vertical, 7)
+                        }
+                        
+                            
                     }
                     
                     
                 }
-                
-                //                }
             }
-            
-            
-            
-            
             
             /// to read frame height...
             GeometryReader{ reader in
                 VStack {
-                    BottomSheetView(offset: $offset, value: (-reader.frame(in: .global).height + 130))
+                    BottomSheetView(offset: $offset, value: (-reader.frame(in: .global).height + 130), issue: issue)
                         .offset(y: reader.frame(in: .global).height - 130)
                         // adding gesture...
                         .offset(y: offset)
@@ -124,11 +146,11 @@ struct SwiftUIView: View {
     }
 }
 
-struct SwiftUIView_Previews: PreviewProvider {
-    static var previews: some View {
-        SwiftUIView()
-    }
-}
+//struct SwiftUIView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        SwiftUIView(issue: issue)
+//    }
+//}
 
 struct BottomSheet: View {
     

--- a/client/iOS/IssueTracker/IssueTracker/SwiftUIView.swift
+++ b/client/iOS/IssueTracker/IssueTracker/SwiftUIView.swift
@@ -73,7 +73,7 @@ struct SwiftUIView: View {
             /// to read frame height...
             GeometryReader{ reader in
                 VStack {
-                    BottomSheet(offset: $offset, value: (-reader.frame(in: .global).height + 130))
+                    BottomSheetView(offset: $offset, value: (-reader.frame(in: .global).height + 130))
                         .offset(y: reader.frame(in: .global).height - 130)
                         // adding gesture...
                         .offset(y: offset)


### PR DESCRIPTION
## 구현내용

### [화면]
<img width="331" alt="스크린샷 2020-10-29 오전 12 29 12" src="https://user-images.githubusercontent.com/62557093/98955203-f943bc80-2541-11eb-9546-9d6b81099a3a.gif">

### [feat]
* custom Bottom View 와 이슈 상세 화면 연결
* 이슈 상세 화면에 issue 데이터 전달 
